### PR TITLE
[#37] 서버 붙이기 완료

### DIFF
--- a/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/RequestModel/YinWaterRequestModel.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/RequestModel/YinWaterRequestModel.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct YinWaterRequestModel: Codable {
+    let type: String
+}

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/RequestModel/YinWeightRequestModel.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/RequestModel/YinWeightRequestModel.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct YinWeightRequestModel {
+    let weight: Double
+    let fatPercent, muscle: Double?
+    let memo: String?
+}

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/RequestModel/YinWeightRequestModel.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/RequestModel/YinWeightRequestModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct YinWeightRequestModel {
+struct YinWeightRequestModel: Codable {
     let weight: Double
     let fatPercent, muscle: Double?
     let memo: String?

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/ResponseModel/YinHealthResponseModel.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/ResponseModel/YinHealthResponseModel.swift
@@ -6,3 +6,32 @@
 //
 
 import Foundation
+
+struct YinHealthResponseModel: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: YinHealthData
+}
+
+struct YinHealthData: Codable {
+    let step: YinStep
+    let calorie: YinCalorie
+    let sleep: YinSleep
+    let weight: Double?
+    let water: Int
+}
+
+struct YinCalorie: Codable {
+    let intake, target: Int
+}
+
+struct YinSleep: Codable {
+    let hour, minute: Int
+    let time: String
+}
+
+struct YinStep: Codable {
+    let count, target, time, activity: Int
+    let percent: Int
+}

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/ResponseModel/YinWaterResponseModel.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/ResponseModel/YinWaterResponseModel.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct YinWaterResponseModel: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+}

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/ResponseModel/YinWeightResponseModel.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkModel/ResponseModel/YinWeightResponseModel.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct YinWeightResponseModel: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+}

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkService/YinWaterService.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Network/YinNetwork/NetworkService/YinWaterService.swift
@@ -5,4 +5,52 @@
 //  Created by 이경민 on 2022/05/29.
 //
 
-import Foundation
+import Alamofire
+
+class YinWaterService {
+    static let shared = YinWaterService()
+    
+    private init() {}
+    
+    func healthWater(waterData: YinWaterRequestModel,
+                      completion: @escaping (NetworkResult<Any>) -> Void)
+    {
+        let url = URLConstant.healthWater
+        let header: HTTPHeaders = ["Content-Type" : "application/json"]
+        
+        let body: Parameters = [
+            "type": waterData.type
+        ]
+        
+        let dataRequest = AF.request(url,
+                                     method: .put,
+                                     parameters: body,
+                                     encoding: JSONEncoding.default,
+                                     headers: header)
+        
+        dataRequest.responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let value = response.value else { return }
+                let networkResult = self.judgeStatus(by: statusCode, value)
+                completion(networkResult)
+            case .failure:
+                completion(.networkFail)
+            }
+        }
+    }
+    
+    func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(YinWaterResponseModel.self, from: data)
+        else { return .pathErr }
+        
+        switch statusCode {
+        case 200 ..< 300: return .success(decodedData)
+        case 401 ..< 500: return .requestErr(decodedData)
+        case 500: return .serverErr
+        default: return .networkFail
+        }
+    }
+}

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/Extension/YinHomeViewController+Network.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/Extension/YinHomeViewController+Network.swift
@@ -8,16 +8,32 @@
 import UIKit
 
 extension YinHomeViewController {
+    
     func getHealth() {
         YinHealthService.shared.health() { response in
             switch response {
             case .success(let data):
                 guard let data = data as? YinHealthData else { return }
                 self.setData(data)
+                self.setWaterBtn(data.water)
                 print(data)
             default:
                 print(response)
             }
         }
     }
+    
+    func putWater(_ waterInput: YinWaterRequestModel) {
+        YinWaterService.shared.healthWater(waterData: waterInput) { response in
+            switch response {
+            case .success(let data):
+                guard let data = data as? YinWaterResponseModel else { return }
+                self.getHealth()
+                print(data)
+            default:
+                print(response)
+            }
+        }
+    }
+    
 }

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/Extension/YinHomeViewController+Network.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/Extension/YinHomeViewController+Network.swift
@@ -5,4 +5,19 @@
 //  Created by 이경민 on 2022/05/14.
 //
 
-import Foundation
+import UIKit
+
+extension YinHomeViewController {
+    func getHealth() {
+        YinHealthService.shared.health() { response in
+            switch response {
+            case .success(let data):
+                guard let data = data as? YinHealthData else { return }
+                self.setData(data)
+                print(data)
+            default:
+                print(response)
+            }
+        }
+    }
+}

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHome.storyboard
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHome.storyboard
@@ -479,15 +479,21 @@
                                                                 </constraints>
                                                                 <state key="normal" title="Button"/>
                                                                 <buttonConfiguration key="configuration" style="plain" image="sshPlusButtonOn"/>
+                                                                <connections>
+                                                                    <action selector="waterPlusBtnDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="fdY-L9-g5T"/>
+                                                                </connections>
                                                             </button>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YLe-LB-iR6">
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YLe-LB-iR6">
                                                                 <rect key="frame" x="266" y="27.5" width="35" height="35"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="35" id="CFI-6g-vq3"/>
                                                                     <constraint firstAttribute="height" constant="35" id="Gxe-sV-sPR"/>
                                                                 </constraints>
                                                                 <state key="normal" title="Button"/>
-                                                                <buttonConfiguration key="configuration" style="plain" image="sshMinusButtonOff"/>
+                                                                <buttonConfiguration key="configuration" style="plain" image="sshMinusButtonOn"/>
+                                                                <connections>
+                                                                    <action selector="waterMinusBtnDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="2z3-2o-KH3"/>
+                                                                </connections>
                                                             </button>
                                                         </subviews>
                                                         <color key="backgroundColor" name="11SshColorBgwhite"/>
@@ -569,6 +575,7 @@
                         <outlet property="stepTargetLabel" destination="cop-pM-LUn" id="cSz-5m-Fl6"/>
                         <outlet property="stepTimeLabel" destination="TxA-qy-jJS" id="yBC-jq-RrM"/>
                         <outlet property="waterLabel" destination="lkK-f7-HBr" id="ieg-hi-HrN"/>
+                        <outlet property="waterMinusButton" destination="YLe-LB-iR6" id="ggl-vZ-iD4"/>
                         <outlet property="weightLabel" destination="MvH-cf-Rpg" id="O7x-dQ-FG1"/>
                         <outletCollection property="titleLabels" destination="qL8-GM-zAU" collectionClass="NSMutableArray" id="oJB-Ih-z7k"/>
                         <outletCollection property="titleLabels" destination="zy4-AW-f34" collectionClass="NSMutableArray" id="Fa4-uL-rOA"/>
@@ -617,7 +624,7 @@
         <image name="sshKnoxlogo" width="101" height="13"/>
         <image name="sshLogo" width="138" height="30"/>
         <image name="sshMenubutton" width="3" height="15"/>
-        <image name="sshMinusButtonOff" width="35" height="35"/>
+        <image name="sshMinusButtonOn" width="35" height="35"/>
         <image name="sshPlusButtonOn" width="35" height="35"/>
         <image name="sshWalkbar" width="113" height="8"/>
         <image name="sshWritebutton" width="113" height="34"/>

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHome.storyboard
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHome.storyboard
@@ -559,6 +559,17 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <size key="freeformSize" width="414" height="1200"/>
                     <connections>
+                        <outlet property="calIntakeLabel" destination="wQn-jh-enH" id="gVl-iD-fwU"/>
+                        <outlet property="calTargetLabel" destination="QwP-8g-2tn" id="UTl-GX-PpN"/>
+                        <outlet property="sleepHourLabel" destination="0Yc-ga-tHv" id="q2K-P7-tUi"/>
+                        <outlet property="sleepMinuteLabel" destination="vtG-JA-crU" id="o2P-RX-BK4"/>
+                        <outlet property="sleepTimeLabel" destination="HcJ-yZ-MOH" id="MKt-CW-gxp"/>
+                        <outlet property="stepActivityLabel" destination="s6N-0D-ksx" id="kPg-17-vLP"/>
+                        <outlet property="stepPercentLabel" destination="LsI-UZ-Mm7" id="oLn-GW-MKA"/>
+                        <outlet property="stepTargetLabel" destination="cop-pM-LUn" id="cSz-5m-Fl6"/>
+                        <outlet property="stepTimeLabel" destination="TxA-qy-jJS" id="yBC-jq-RrM"/>
+                        <outlet property="waterLabel" destination="lkK-f7-HBr" id="ieg-hi-HrN"/>
+                        <outlet property="weightLabel" destination="MvH-cf-Rpg" id="O7x-dQ-FG1"/>
                         <outletCollection property="titleLabels" destination="qL8-GM-zAU" collectionClass="NSMutableArray" id="oJB-Ih-z7k"/>
                         <outletCollection property="titleLabels" destination="zy4-AW-f34" collectionClass="NSMutableArray" id="Fa4-uL-rOA"/>
                         <outletCollection property="titleLabels" destination="t0c-ZJ-83T" collectionClass="NSMutableArray" id="Muo-jH-LFE"/>
@@ -584,6 +595,8 @@
                         <outletCollection property="h1Labels" destination="lkK-f7-HBr" collectionClass="NSMutableArray" id="Hrk-ts-7Ls"/>
                         <outletCollection property="c1Labels" destination="LsI-UZ-Mm7" collectionClass="NSMutableArray" id="6Kj-xJ-4Qa"/>
                         <outletCollection property="c1Labels" destination="HcJ-yZ-MOH" collectionClass="NSMutableArray" id="KxE-Km-0Ri"/>
+                        <outletCollection property="stepCountLabels" destination="AKH-YT-soY" collectionClass="NSMutableArray" id="CUb-g6-wF7"/>
+                        <outletCollection property="stepCountLabels" destination="X3R-Z8-SwR" collectionClass="NSMutableArray" id="oT8-T0-dtU"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHomeViewController.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHomeViewController.swift
@@ -16,11 +16,25 @@ class YinHomeViewController: UIViewController {
     @IBOutlet var b2Labels: [UILabel]!
     @IBOutlet var c1Labels: [UILabel]!
     
+    @IBOutlet var stepCountLabels: [UILabel]!
+    @IBOutlet weak var stepTargetLabel: UILabel!
+    @IBOutlet weak var stepTimeLabel: UILabel!
+    @IBOutlet weak var stepActivityLabel: UILabel!
+    @IBOutlet weak var stepPercentLabel: UILabel!
+    @IBOutlet weak var calIntakeLabel: UILabel!
+    @IBOutlet weak var calTargetLabel: UILabel!
+    @IBOutlet weak var sleepHourLabel: UILabel!
+    @IBOutlet weak var sleepMinuteLabel: UILabel!
+    @IBOutlet weak var sleepTimeLabel: UILabel!
+    @IBOutlet weak var weightLabel: UILabel!
+    @IBOutlet weak var waterLabel: UILabel!
+    
     // MARK: - VC Life Cycle (or Cell Life Cycle)
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
+        getHealth()
     }
     
     // MARK: - Function
@@ -34,6 +48,21 @@ class YinHomeViewController: UIViewController {
         b2Labels.forEach { $0.font = .SshFontB2 }
         c1Labels.forEach { $0.font = .SshFontC1 }
     }
+    
+    func setData(_ data: YinHealthData) {
+        stepCountLabels.forEach() { $0.text = "\(data.step.count)" }
+        stepTargetLabel.text = "/\(data.step.target)"
+        stepPercentLabel.text = "\(data.step.percent)%"
+        stepTimeLabel.text = "\(data.step.time)"
+        stepActivityLabel.text = "\(data.step.activity)"
+        calIntakeLabel.text = "\(data.calorie.intake)"
+        calTargetLabel.text = "/\(data.calorie.target)kcal"
+        sleepHourLabel.text = "\(data.sleep.hour)"
+        sleepMinuteLabel.text = "\(data.sleep.minute)"
+        sleepTimeLabel.text = "\(data.sleep.time)"
+        weightLabel.text = "\(data.weight ?? 0.0)"
+        waterLabel.text = "\(data.water)"
+    }
 
     // MARK: - IBAction
     @IBAction func weightBtnDidTap(_ sender: Any) {
@@ -41,5 +70,4 @@ class YinHomeViewController: UIViewController {
         weightVC.modalPresentationStyle = .fullScreen
         present(weightVC, animated: true)
     }
-    
 }

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHomeViewController.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHomeViewController.swift
@@ -9,6 +9,9 @@ import UIKit
 
 class YinHomeViewController: UIViewController {
     
+    // MARK: - Properties
+    var weight = Double(0.0)
+    
     // MARK: - IBOutlet
     
     @IBOutlet var titleLabels: [UILabel]!
@@ -63,7 +66,8 @@ class YinHomeViewController: UIViewController {
         sleepHourLabel.text = "\(data.sleep.hour)"
         sleepMinuteLabel.text = "\(data.sleep.minute)"
         sleepTimeLabel.text = "\(data.sleep.time)"
-        weightLabel.text = "\(data.weight ?? 0.0)"
+        weight = data.weight ?? 0.0
+        weightLabel.text = "\(weight)"
         waterLabel.text = "\(data.water)"
     }
 
@@ -71,6 +75,7 @@ class YinHomeViewController: UIViewController {
     @IBAction func weightBtnDidTap(_ sender: Any) {
         guard let weightVC = UIStoryboard(name: Const.Storyboard.YinWeight, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.YinWeightViewController) as? YinWeightViewController else { return }
         weightVC.modalPresentationStyle = .fullScreen
+        weightVC.weight = weight
         present(weightVC, animated: true)
     }
 }

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHomeViewController.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHomeViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class YinHomeViewController: UIViewController {
     
     // MARK: - Properties
+    
     var weight = Double(0.0)
     
     // MARK: - IBOutlet
@@ -32,6 +33,8 @@ class YinHomeViewController: UIViewController {
     @IBOutlet weak var weightLabel: UILabel!
     @IBOutlet weak var waterLabel: UILabel!
     
+    @IBOutlet weak var waterMinusButton: UIButton!
+    
     // MARK: - VC Life Cycle (or Cell Life Cycle)
     
     override func viewWillAppear(_ animated: Bool) {
@@ -44,6 +47,7 @@ class YinHomeViewController: UIViewController {
     }
     
     // MARK: - Function
+    
     private func setUI() {
         setFont()
     }
@@ -70,12 +74,33 @@ class YinHomeViewController: UIViewController {
         weightLabel.text = "\(weight)"
         waterLabel.text = "\(data.water)"
     }
+    
+    func setWaterBtn(_ water: Int) {
+        if (water == 0) {
+            waterMinusButton.setImage(Const.Image.sshMinusButtonOff, for: .normal)
+            waterMinusButton.isEnabled = false
+        } else {
+            waterMinusButton.setImage(Const.Image.sshMinusButtonOn, for: .normal)
+            waterMinusButton.isEnabled = true
+        }
+    }
 
     // MARK: - IBAction
+    
     @IBAction func weightBtnDidTap(_ sender: Any) {
         guard let weightVC = UIStoryboard(name: Const.Storyboard.YinWeight, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.YinWeightViewController) as? YinWeightViewController else { return }
         weightVC.modalPresentationStyle = .fullScreen
         weightVC.weight = weight
         present(weightVC, animated: true)
     }
+    
+    
+    @IBAction func waterMinusBtnDidTap(_ sender: Any) {
+        putWater(YinWaterRequestModel(type: "-"))
+    }
+    
+    @IBAction func waterPlusBtnDidTap(_ sender: Any) {
+        putWater(YinWaterRequestModel(type: "+"))
+    }
+    
 }

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHomeViewController.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Home/YinHomeViewController.swift
@@ -31,10 +31,13 @@ class YinHomeViewController: UIViewController {
     
     // MARK: - VC Life Cycle (or Cell Life Cycle)
     
+    override func viewWillAppear(_ animated: Bool) {
+        getHealth()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
-        getHealth()
     }
     
     // MARK: - Function

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Weight/Extension/YinWeightViewController+Network.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Weight/Extension/YinWeightViewController+Network.swift
@@ -5,4 +5,17 @@
 //  Created by 이경민 on 2022/05/14.
 //
 
-import Foundation
+extension YinWeightViewController {
+    func postWeight(_ weightInput: YinWeightRequestModel) {
+        YinWeightService.shared.healthWeight(weightData: weightInput) { response in
+            switch response {
+            case .success(let data):
+                guard let data = data as? YinWeightResponseModel else { return }
+                self.dismiss(animated: true)
+                print(data)
+            default:
+                print(response)
+            }
+        }
+    }
+}

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Weight/YinWeight.storyboard
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Weight/YinWeight.storyboard
@@ -168,20 +168,25 @@
                                                                     <constraint firstAttribute="height" constant="14" id="qNG-GT-cPC"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="메모" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KDA-Yp-ne2">
-                                                                <rect key="frame" x="52" y="17" width="26" height="18"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
-                                                                <color key="textColor" name="11SshColorGray2"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="메모" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fvk-ka-Rct">
+                                                                <rect key="frame" x="52" y="17" width="284" height="18.5"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no"/>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderLabel.textColor">
+                                                                        <color key="value" name="11SshColorGray2"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                </userDefinedRuntimeAttributes>
+                                                            </textField>
                                                         </subviews>
                                                         <color key="backgroundColor" name="11SshColorBgwhite"/>
                                                         <constraints>
-                                                            <constraint firstItem="KDA-Yp-ne2" firstAttribute="centerY" secondItem="9hl-OB-L6K" secondAttribute="centerY" id="11d-cf-W5y"/>
+                                                            <constraint firstItem="fvk-ka-Rct" firstAttribute="centerY" secondItem="9hl-OB-L6K" secondAttribute="centerY" id="NTl-QA-6DT"/>
                                                             <constraint firstAttribute="height" constant="52" id="VRo-Fo-8vx"/>
                                                             <constraint firstItem="BFD-ZV-Gwa" firstAttribute="leading" secondItem="9hl-OB-L6K" secondAttribute="leading" constant="20" id="Zpr-1m-hPe"/>
+                                                            <constraint firstItem="fvk-ka-Rct" firstAttribute="leading" secondItem="BFD-ZV-Gwa" secondAttribute="trailing" constant="20" id="lPc-Vp-xKN"/>
                                                             <constraint firstItem="BFD-ZV-Gwa" firstAttribute="centerY" secondItem="9hl-OB-L6K" secondAttribute="centerY" id="owh-cy-GRP"/>
-                                                            <constraint firstItem="KDA-Yp-ne2" firstAttribute="leading" secondItem="BFD-ZV-Gwa" secondAttribute="trailing" constant="20" id="xlC-YY-Wz3"/>
+                                                            <constraint firstAttribute="trailing" secondItem="fvk-ka-Rct" secondAttribute="trailing" constant="10" id="zHz-pa-150"/>
                                                         </constraints>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="20"/>
@@ -234,6 +239,9 @@
                                             <fontDescription key="titleFontDescription" type="system" pointSize="18"/>
                                             <color key="baseForegroundColor" name="11SshColorBlack1"/>
                                         </buttonConfiguration>
+                                        <connections>
+                                            <action selector="cancelWeightBtnDidTap:" destination="4Mq-Wr-Ove" eventType="touchUpInside" id="FlW-VN-Qm0"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P3x-Oh-j6q">
                                         <rect key="frame" x="254.5" y="20.5" width="55.5" height="35.5"/>
@@ -242,6 +250,9 @@
                                             <fontDescription key="titleFontDescription" type="system" pointSize="18"/>
                                             <color key="baseForegroundColor" name="11SshColorBlack1"/>
                                         </buttonConfiguration>
+                                        <connections>
+                                            <action selector="addWeightBtnDidTap:" destination="4Mq-Wr-Ove" eventType="touchUpInside" id="ULr-PR-ev2"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" name="11SshColorBggray"/>
@@ -270,6 +281,7 @@
                     <size key="freeformSize" width="376" height="800"/>
                     <connections>
                         <outlet property="dateLabel" destination="IXl-Am-rth" id="PpD-oG-2U9"/>
+                        <outlet property="memoTextField" destination="fvk-ka-Rct" id="Xae-s6-X4u"/>
                         <outlet property="muscleTextField" destination="pTu-gL-lZY" id="YYA-YG-L7V"/>
                         <outlet property="titleLabel" destination="9ME-ry-TlK" id="sZ1-da-Is2"/>
                         <outlet property="weightPickerView" destination="b58-bb-vdu" id="YvZ-5V-MAe"/>
@@ -277,7 +289,6 @@
                         <outletCollection property="titleLabels" destination="HCC-MI-dPQ" collectionClass="NSMutableArray" id="Cud-4i-q7o"/>
                         <outletCollection property="titleLabels" destination="clc-vK-Sf2" collectionClass="NSMutableArray" id="NX7-rM-7F7"/>
                         <outletCollection property="titleLabels" destination="vRj-SU-2zF" collectionClass="NSMutableArray" id="kfm-92-qfr"/>
-                        <outletCollection property="titleLabels" destination="KDA-Yp-ne2" collectionClass="NSMutableArray" id="CEh-IY-k5p"/>
                         <outletCollection property="typeLabels" destination="w2o-te-44O" collectionClass="NSMutableArray" id="iPV-Q1-3Yu"/>
                         <outletCollection property="typeLabels" destination="bf8-od-fw7" collectionClass="NSMutableArray" id="nuh-uK-rfG"/>
                         <outletCollection property="msgLabels" destination="OSk-v5-p2z" collectionClass="NSMutableArray" id="a9c-dT-xcB"/>

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Weight/YinWeightViewController.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Weight/YinWeightViewController.swift
@@ -11,7 +11,7 @@ class YinWeightViewController: UIViewController {
     
     // MARK: - Properties
     
-    var weight = Float(0.0)
+    var weight = Double(0.0)
     
     // MARK: - IBOutlet
     
@@ -25,6 +25,7 @@ class YinWeightViewController: UIViewController {
     @IBOutlet weak var weightPickerView: UIPickerView!
     @IBOutlet weak var weightTextField: UITextField!
     @IBOutlet weak var muscleTextField: UITextField!
+    @IBOutlet weak var memoTextField: UITextField!
     
     // MARK: - VC Life Cycle (or Cell Life Cycle)
     
@@ -61,6 +62,7 @@ class YinWeightViewController: UIViewController {
         msgLabels.forEach { $0.font = .SshFontB3 }
         titleLabels.forEach { $0.font = .NotoSans(.medium, size: 15) }
         typeLabels.forEach { $0.font = .NotoSans(.medium, size: 13)}
+        memoTextField.font = .NotoSans(.medium, size: 15)
     }
     
     private func initPickerView() {
@@ -82,8 +84,19 @@ class YinWeightViewController: UIViewController {
         }
     }
     
-    // MARK: - objc Function
     // MARK: - IBAction
+    @IBAction func cancelWeightBtnDidTap(_ sender: Any) {
+        dismiss(animated: true)
+    }
+    
+    @IBAction func addWeightBtnDidTap(_ sender: Any) {
+        postWeight(YinWeightRequestModel(
+            weight: weight,
+            fatPercent: Double(weightTextField.text ?? ""),
+            muscle: Double(muscleTextField.text ?? ""),
+            memo: memoTextField.text)
+        )
+    }
     
 }
 
@@ -117,8 +130,7 @@ extension YinWeightViewController: UIPickerViewDelegate, UIPickerViewDataSource 
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        weight = Float(pickerView.selectedRow(inComponent: 0))
-        weight += (Float(pickerView.selectedRow(inComponent: 2)) * 0.1)
+        weight = Double(pickerView.selectedRow(inComponent: 0))
+        weight += (Double(pickerView.selectedRow(inComponent: 2)) * 0.1)
     }
-    
 }

--- a/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Weight/YinWeightViewController.swift
+++ b/SamsungHealth-iOS/SamsungHealth-iOS/Scene(yi)/Weight/YinWeightViewController.swift
@@ -67,6 +67,10 @@ class YinWeightViewController: UIViewController {
     
     private func initPickerView() {
         weightPickerView.subviews[1].backgroundColor = .clear
+        let first = Int(weight)
+        let second = Int(weight * 10) - (first * 10)
+        weightPickerView.selectRow(first, inComponent: 0, animated: false)
+        weightPickerView.selectRow(second, inComponent: 2, animated: false)
     }
     
     private func setPickerView() {


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number를 적어주세요 -->
closed #37 

## 참고사항
### 전체 건강 조회
viewWillAppear에서 API 호출하여 체중 기록 저장 후 dismiss한 후에도 체중 기록되게 구현

### 체중 기록
전체 건강 조회로 받은 체중을 체중입력 페이지의 피커뷰에 나타나게 구현
`프로퍼티 접근 방식으로 했는데 closure나 delegate패턴 쓰는 게 나을까여 ?`
`그리고 double을 자릿수 나누느라 더러운 계산을 했는데 ㅋㅋ 이걸 어떻게 해야할까요 ㅋㅋ`

### 물 기록
(-) 나 (+) 버튼 누르면, 전체 건강 조회 API 호출함으로써 바로 반영되게 구현
이 때, 0잔이 되면 더 이상 (-)버튼 사용할 수 없도록 함
How ? 전체 건강 조회에 성공시 물의 값이 0인지 아닌지 확인해서 (-)버튼의 이미지 및 사용 여부 설정

`아 그리고 header가 const로 빠져있던데 어떻게 쓰는지 모르겠어요 ><`

## 스크린샷
| 구현 내용 | 스크린샷 |
| :---: | :---: |
| 전체 건강 조회 | ![Simulator Screen Recording - iPhone 8 - 2022-05-31 at 21 32 16](https://user-images.githubusercontent.com/74968390/171174249-2fcf86a7-c0fd-4300-a1bf-7727449ecabc.gif) |
| 체중 기록 | ![Simulator Screen Recording - iPhone 8 - 2022-05-31 at 21 35 55](https://user-images.githubusercontent.com/74968390/171174650-af65be01-06da-4e9a-9da2-121e33f903f5.gif) |
| 물 기록 | ![Simulator Screen Recording - iPhone 8 - 2022-05-31 at 21 33 01](https://user-images.githubusercontent.com/74968390/171174327-dcfc6830-8245-4da1-b59e-beb0dd6362f1.gif) |

